### PR TITLE
fix: load and save for multifile was not working properly

### DIFF
--- a/src/filedump.jl
+++ b/src/filedump.jl
@@ -42,7 +42,7 @@ function vectorToCommaSeparatedString(vector::Vector{String})
 end
 
 function save(metadataFilepath::String, data::CompressedMultiFileArraySeq)
-    nameWithoutExtension = split(metadataFilepath, ".")[1]
+    nameWithoutExtension = metadataFilepath[begin:findlast(".", metadataFilepath)[1]-1]
     dataFilepath = map(1:length(data.files)) do i
         nameWithoutExtension * "_data_" * string(i) * ".bin"
     end
@@ -101,7 +101,7 @@ function loadCompressedMultiFileArraySeq(io)
     read!(io, headpositions)
     read!(io, tailpositions)
     dataFilepathString = read(io, String)
-    dataFilepath = split(dataFilepathString, ",")
+    dataFilepath = string.(split(dataFilepathString, ","))
 
     files = map(dataFilepath) do path
         open(path, "r+")
@@ -117,7 +117,8 @@ function loadCompressedMultiFileArraySeq(io)
               tol,
               precision,
               rate,
-              nth
+              nth,
+              dataFilepath
            )
 end
 

--- a/src/filedump.jl
+++ b/src/filedump.jl
@@ -42,7 +42,11 @@ function vectorToCommaSeparatedString(vector::Vector{String})
 end
 
 function save(metadataFilepath::String, data::CompressedMultiFileArraySeq)
-    nameWithoutExtension = metadataFilepath[begin:findlast(".", metadataFilepath)[1]-1]
+    if occursin(".", metadataFilepath)
+        nameWithoutExtension = metadataFilepath[begin:findlast(".", metadataFilepath)[1]-1]
+    else
+        nameWithoutExtension = metadataFilepath
+    end
     dataFilepath = map(1:length(data.files)) do i
         nameWithoutExtension * "_data_" * string(i) * ".bin"
     end

--- a/src/multifile.jl
+++ b/src/multifile.jl
@@ -81,9 +81,10 @@ mutable struct CompressedMultiFileArraySeq{T,Nx} <: AbstractCompArraySeq
         tol::Float32,
         precision::Int64,
         rate::Int64,
-        nth::Int16) where Nx
+        nth::Int16,
+        filePaths::Vector{String}) where Nx
 
-        return new{eltype, length(spacedim)}(files, headpositions, tailpositions, spacedim, timedim, eltype, tol, precision, rate, nth)
+        return new{eltype, length(spacedim)}(files, headpositions, tailpositions, spacedim, timedim, eltype, tol, precision, rate, nth, filePaths)
     end
 end
 


### PR DESCRIPTION
fix: load and save for multifile was not working properly with big filepath strings, I assume it was because of a julia update