### PR TITLE
Fixing bug where files were not deleted after GC

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.10'
+          - '1.12'
         os:
           - ubuntu-latest
         arch:

--- a/src/SequentialZfpCompression.jl
+++ b/src/SequentialZfpCompression.jl
@@ -12,6 +12,6 @@ include("multifile.jl")
 include("unified_constructor.jl")
 include("filedump.jl")
 
-export SeqCompressor, save, load, totalsize
+export SeqCompressor, save, load, totalsize, cleanup!
 
 end

--- a/src/multifile.jl
+++ b/src/multifile.jl
@@ -1,4 +1,25 @@
 """
+    finalizeMultiFile(comp)
+
+Cleanup function for `CompressedMultiFileArraySeq`. Closes all open file streams
+and removes the temporary files from disk.
+
+# Arguments
+- `comp`: A `CompressedMultiFileArraySeq` object containing the file streams and paths to clean up.
+"""
+function finalizeMultiFile(comp)
+    for (io, path) in zip(comp.files, comp.filePaths)
+        if isopen(io) 
+            close(io)
+        end
+        if isfile(path)
+            rm(path, force=true)
+        end
+    end
+end
+
+
+"""
     CompressedMultiFileArraySeq{T,Nx}
 
 A compressed time-dependent array that is stored in multiple files, one per thread.
@@ -68,16 +89,7 @@ mutable struct CompressedMultiFileArraySeq{T,Nx} <: AbstractCompArraySeq
         timedim = 0
 
         obj = new{dtype, length(spacedim)}(ioVector, headpositions, tailpositions, spacedim, timedim, eltype, tol, precision, rate, nth, paths)
-        finalizer(obj) do comp
-            for (io, path) in zip(comp.files, comp.filePaths)
-                if isopen(io) 
-                    close(io)
-                end
-                if isfile(path)
-                    rm(path, force=true)
-                end
-            end
-        end
+        finalizer(finalizeMultiFile, obj)
         return obj
     end
 
@@ -96,17 +108,7 @@ mutable struct CompressedMultiFileArraySeq{T,Nx} <: AbstractCompArraySeq
         filePaths::Vector{String}) where Nx
 
         obj = new{eltype, length(spacedim)}(files, headpositions, tailpositions, spacedim, timedim, eltype, tol, precision, rate, nth, filePaths)
-        finalizer(obj) do comp
-            for (io, path) in zip(comp.files, comp.filePaths)
-                if isopen(io) 
-                    close(io)
-                end
-                if isfile(path)
-                    rm(path, force=true)
-                end
-            end
-        end
-        return obj
+        finalizer(finalizeMultiFile, obj)
     end
 end
 

--- a/src/multifile.jl
+++ b/src/multifile.jl
@@ -7,7 +7,7 @@ and removes the temporary files from disk.
 # Arguments
 - `comp`: A `CompressedMultiFileArraySeq` object containing the file streams and paths to clean up.
 """
-function finalizeMultiFile(comp)
+function finalizeMultiFile!(comp)
     for (io, path) in zip(comp.files, comp.filePaths)
         if isopen(io) 
             close(io)
@@ -89,7 +89,7 @@ mutable struct CompressedMultiFileArraySeq{T,Nx} <: AbstractCompArraySeq
         timedim = 0
 
         obj = new{dtype, length(spacedim)}(ioVector, headpositions, tailpositions, spacedim, timedim, eltype, tol, precision, rate, nth, paths)
-        finalizer(finalizeMultiFile, obj)
+        finalizer(finalizeMultiFile!, obj)
         return obj
     end
 
@@ -108,7 +108,7 @@ mutable struct CompressedMultiFileArraySeq{T,Nx} <: AbstractCompArraySeq
         filePaths::Vector{String}) where Nx
 
         obj = new{eltype, length(spacedim)}(files, headpositions, tailpositions, spacedim, timedim, eltype, tol, precision, rate, nth, filePaths)
-        finalizer(finalizeMultiFile, obj)
+        finalizer(finalizeMultiFile!, obj)
     end
 end
 
@@ -179,4 +179,18 @@ Returns the total size of the compressed data in bytes.
 """
 function totalsize(compArray::CompressedMultiFileArraySeq)
     return sum(map(filesize, compArray.files))
+end
+
+
+"""
+    cleanup!(comp:CompressedMultiFileArraySeq)
+
+Cleanup function for `CompressedMultiFileArraySeq`. Closes all open file streams
+and removes the temporary files from disk.
+
+# Arguments
+- `comp`: A `CompressedMultiFileArraySeq` object containing the file streams and paths to clean up.
+"""
+function cleanup!(comp::CompressedMultiFileArraySeq)
+    finalizeMultiFile!(comp)
 end

--- a/src/multifile.jl
+++ b/src/multifile.jl
@@ -67,7 +67,18 @@ mutable struct CompressedMultiFileArraySeq{T,Nx} <: AbstractCompArraySeq
         eltype = dtype
         timedim = 0
 
-        return new{dtype, length(spacedim)}(ioVector, headpositions, tailpositions, spacedim, timedim, eltype, tol, precision, rate, nth, paths)
+        obj = new{dtype, length(spacedim)}(ioVector, headpositions, tailpositions, spacedim, timedim, eltype, tol, precision, rate, nth, paths)
+        finalizer(obj) do comp
+            for (io, path) in zip(comp.files, comp.filePaths)
+                if isopen(io) 
+                    close(io)
+                end
+                if isfile(path)
+                    rm(path, force=true)
+                end
+            end
+        end
+        return obj
     end
 
     # For custom outer constructors
@@ -84,7 +95,18 @@ mutable struct CompressedMultiFileArraySeq{T,Nx} <: AbstractCompArraySeq
         nth::Int16,
         filePaths::Vector{String}) where Nx
 
-        return new{eltype, length(spacedim)}(files, headpositions, tailpositions, spacedim, timedim, eltype, tol, precision, rate, nth, filePaths)
+        obj = new{eltype, length(spacedim)}(files, headpositions, tailpositions, spacedim, timedim, eltype, tol, precision, rate, nth, filePaths)
+        finalizer(obj) do comp
+            for (io, path) in zip(comp.files, comp.filePaths)
+                if isopen(io) 
+                    close(io)
+                end
+                if isfile(path)
+                    rm(path, force=true)
+                end
+            end
+        end
+        return obj
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,3 +71,28 @@ end
         end
     end
 end
+
+function tempFunction()
+    dtype = Float32
+    dims = (100, 100)
+    B = rand(dtype, dims...,3)
+
+    Bc = sc.SeqCompressor(dtype, dims..., filepaths="/tmp/tempFolderThatShouldHaveItsFilesDeletedOnGC")
+
+    for i = 1:3
+        append!(Bc, selectdim(B, ndims(B), i) |> copy)
+    end
+
+    filePaths = copy(Bc.filePaths)
+
+    sc.cleanup!(Bc)
+
+    return filePaths
+end
+
+@testset "test finalizer" begin
+
+    filePaths = tempFunction()
+    
+    @test !any(isfile.(filePaths))
+end


### PR DESCRIPTION
There was an issue I noticed when making heavy use of this package where the files were not deleted after the multifile type object was garbage collected. To fix it I added a finalizer to close and delete the files when that happens.